### PR TITLE
feat: 폼 제출 및 결과 화면 구현 (#10)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,14 @@
 import { Header } from '@/shared/ui/Header';
 import { FormEditor } from '@/features/builder/ui/FormEditor';
 import { PreviewPanel } from '@/features/preview/ui/PreviewPanel';
+import { ResultView } from '@/features/result/ui/ResultView';
+import { useAppStore } from '@/shared/stores/useAppStore';
 
 export default function App() {
+  const view = useAppStore((s) => s.view);
+
+  if (view === 'result') return <ResultView />;
+
   return (
     <div className="min-h-screen bg-surface">
       <Header />

--- a/src/features/preview/ui/PreviewPanel.tsx
+++ b/src/features/preview/ui/PreviewPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useFormStore } from '@/shared/stores/useFormStore';
+import { useAppStore } from '@/shared/stores/useAppStore';
 
 export function PreviewPanel() {
   const { title, fields } = useFormStore();
@@ -9,7 +10,7 @@ export function PreviewPanel() {
   // 에러 상태
   const [errors, setErrors] = useState<Record<string, string>>({});
   // 제출 완료 여부
-  const [submitted, setSubmitted] = useState(false);
+  const { setView, setSubmittedData } = useAppStore();
 
   const updateValue = (id: string, value: string | string[]) => {
     setValues((prev) => ({ ...prev, [id]: value }));
@@ -42,16 +43,10 @@ export function PreviewPanel() {
 
   const handleSubmit = () => {
     if (validate()) {
-      setSubmitted(true);
+      setSubmittedData(values);
+      setView('result');
     }
   };
-
-  // 제출 완료 시 결과 화면 (임시 — #10에서 분리)
-  if (submitted) {
-    return (
-      <div className="text-center text-sm text-muted">제출 완료! (#10에서 결과 화면 구현 예정)</div>
-    );
-  }
 
   return (
     <div className="flex flex-col gap-8">

--- a/src/features/result/ui/ResultView.tsx
+++ b/src/features/result/ui/ResultView.tsx
@@ -1,0 +1,68 @@
+import { useFormStore } from '@/shared/stores/useFormStore';
+import { useAppStore } from '@/shared/stores/useAppStore';
+
+export function ResultView() {
+  const fields = useFormStore((s) => s.fields);
+  const { submittedData, setView, setSubmittedData } = useAppStore();
+
+  const handleNewResponse = () => {
+    setSubmittedData({});
+    setView('builder');
+  };
+
+  return (
+    <div className="min-h-screen bg-surface flex items-center justify-center px-4">
+      <div className="bg-white rounded-2xl shadow-sm max-w-[520px] w-full px-9 py-10">
+        {/* 성공 헤더 */}
+        <div className="flex flex-col items-center">
+          <div className="size-12 rounded-full bg-success/10 flex items-center justify-center text-success text-2xl">
+            ✓
+          </div>
+          <h1 className="text-xl font-medium text-text mt-4">제출 완료</h1>
+          <p className="text-[13px] text-muted mt-1">응답이 성공적으로 기록되었습니다.</p>
+        </div>
+
+        {/* key-value 테이블 */}
+        <div className="mt-8">
+          {fields.map((field) => (
+            <div
+              key={field.id}
+              className="flex items-center justify-between py-3 border-b border-[#F0F0F0]"
+            >
+              <span className="text-[13px] text-muted">{field.label || '(라벨 없음)'}</span>
+              <div className="text-[13px] text-text text-right">
+                {Array.isArray(submittedData[field.id]) ? (
+                  <div className="flex gap-1.5 flex-wrap justify-end">
+                    {(submittedData[field.id] as string[]).map((v) => (
+                      <span key={v} className="bg-surface px-3 py-1 rounded-full text-xs">
+                        {v}
+                      </span>
+                    ))}
+                  </div>
+                ) : (
+                  submittedData[field.id] || '-'
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* 버튼 */}
+        <div className="grid grid-cols-2 gap-3 mt-8">
+          <button
+            onClick={handleNewResponse}
+            className="h-11 rounded-xl border border-[#D1D5DB] text-sm text-text hover:bg-[#F9FAFB] cursor-pointer"
+          >
+            새 응답 작성
+          </button>
+          <button
+            onClick={() => setView('builder')}
+            className="h-11 rounded-xl bg-primary text-sm text-white hover:bg-primary-hover cursor-pointer"
+          >
+            폼으로 돌아가기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/stores/useAppStore.ts
+++ b/src/shared/stores/useAppStore.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+interface AppStore {
+  view: 'builder' | 'result';
+  submittedData: Record<string, string | string[]>;
+  setView: (view: 'builder' | 'result') => void;
+  setSubmittedData: (data: Record<string, string | string[]>) => void;
+}
+
+export const useAppStore = create<AppStore>((set) => ({
+  view: 'builder',
+  submittedData: {},
+  setView: (view) => set({ view }),
+  setSubmittedData: (data) => set({ submittedData: data }),
+}));


### PR DESCRIPTION
## 📌 PR 개요
폼 제출 후 입력값을 확인할 수 있는 결과 화면 구현

## 🔍 관련 이슈
Closes #10

## 🔧 변경 유형
- [x] ✨ feat (새 기능 추가)

## ✨ 변경 사항
- `useAppStore` 생성 — 뷰 전환(builder/result) + 제출 데이터 관리
- `ResultView` 컴포넌트 — 체크 아이콘 + 제출 완료 메시지 + key-value 테이블
  - 다중 선택 값은 pill 형태로 표시
  - "새 응답 작성" / "폼으로 돌아가기" 버튼
- `App.tsx` 업데이트 — useAppStore view 상태로 builder/result 뷰 전환
- `PreviewPanel` 수정 — 제출 성공 시 submittedData 저장 후 result 뷰로 전환, submitted useState 제거

## ✅ 체크리스트
- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 🤝 기타 참고 사항
- React Router 없이 Zustand 상태 기반 뷰 전환 — SPA 과제 특성상 간결한 방식 채택
- Figma 결과 페이지 시안 기준 디자인 적용