### PR TITLE
feat: 모바일 대응 (#11)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Header } from '@/shared/ui/Header';
 import { FormEditor } from '@/features/builder/ui/FormEditor';
 import { PreviewPanel } from '@/features/preview/ui/PreviewPanel';
@@ -6,17 +7,39 @@ import { useAppStore } from '@/shared/stores/useAppStore';
 
 export default function App() {
   const view = useAppStore((s) => s.view);
+  const [tab, setTab] = useState<'edit' | 'preview'>('edit');
 
   if (view === 'result') return <ResultView />;
 
   return (
     <div className="min-h-screen bg-surface">
       <Header />
-      <main className="flex pt-14">
-        <div className="w-[60%] border-r border-border/10 px-8 py-6">
+      {/* 모바일 탭 */}
+      <div className="flex md:hidden border-b border-border/30 pt-14">
+        <button
+          onClick={() => setTab('edit')}
+          className={`flex-1 py-3 text-sm font-medium cursor-pointer ${tab === 'edit' ? 'text-primary border-b-2 border-primary' : 'text-muted'}`}
+        >
+          편집
+        </button>
+        <button
+          onClick={() => setTab('preview')}
+          className={`flex-1 py-3 text-sm font-medium cursor-pointer ${tab === 'preview' ? 'text-primary border-b-2 border-primary' : 'text-muted'}`}
+        >
+          미리보기
+        </button>
+      </div>
+
+      {/* 데스크톱: 2-column / 모바일: 탭 전환 */}
+      <main className="flex pt-14 md:pt-14">
+        <div
+          className={`w-full md:w-[60%] md:border-r border-border/10 px-6 md:px-8 py-6 ${tab !== 'edit' ? 'hidden md:block' : ''}`}
+        >
           <FormEditor />
         </div>
-        <div className="w-[40%] px-8 py-6">
+        <div
+          className={`w-full md:w-[40%] px-6 md:px-8 py-6 ${tab !== 'preview' ? 'hidden md:block' : ''}`}
+        >
           <PreviewPanel />
         </div>
       </main>


### PR DESCRIPTION
## 📌 PR 개요
모바일 환경에서 편집/미리보기 탭 전환 방식으로 반응형 대응

## 🔍 관련 이슈
Closes #11

## 🔧 변경 유형
- [x] ✨ feat (새 기능 추가)

## ✨ 변경 사항
- 768px 미만: 1-column + 편집/미리보기 탭 전환
- 768px 이상: 기존 2-column 레이아웃 유지
- `md:` 브레이크포인트 기반 조건부 표시

## ✅ 체크리스트
- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 🤝 기타 참고 사항
- React Router 없이 useState로 탭 상태 관리
- 데스크톱에서는 탭 UI가 `hidden`으로 숨겨져 기존 동작에 영향 없음